### PR TITLE
Improve mobile task layout and countdown display

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,7 @@
         </select>
       </div>
       <div class="task-step hidden" id="task-step-3">
+        <textarea id="task-desc" placeholder="Descrição" maxlength="60"></textarea>
         <h3>Tempo da tarefa</h3>
         <div class="time-inputs">
           <input type="number" id="task-hours" min="0" value="0" />

--- a/styles.css
+++ b/styles.css
@@ -256,6 +256,9 @@ li:hover { transform: scale(1.02); }
   padding: 10px;
   margin-bottom: 10px;
   border-radius: 8px;
+  position: relative;
+  display: flex;
+  align-items: center;
 }
 
 .task-item.pending {
@@ -278,6 +281,37 @@ li:hover { transform: scale(1.02); }
 .task-item span {
   font-size: 14px;
   color: #555;
+}
+
+.task-aspect-icon {
+  width: 40px;
+  height: 40px;
+  margin-right: 10px;
+}
+
+.task-text {
+  flex: 1;
+}
+
+.task-timer {
+  position: absolute;
+  top: 10px;
+  right: 20px;
+  text-align: right;
+}
+
+.task-timer small {
+  display: block;
+  font-size: 10px;
+  line-height: 1;
+}
+
+#task-desc {
+  margin-bottom: 5px;
+}
+
+.task-form h3 {
+  margin: 5px 0;
 }
 
 #tasks-hub {
@@ -578,7 +612,7 @@ li:hover { transform: scale(1.02); }
   #logo-screen #logo,
   .aspect-image { width: 210px; }
   .menu-item img,
-  .menu-carousel img { width: 105px; height: 105px; }
+  .menu-carousel img { width: 140px; height: 140px; }
   #main-header { height: 42px; }
   .header-container { padding: 7px 30px; }
   .header-logo { height: 28px; }


### PR DESCRIPTION
## Summary
- Add task description field inside creation/edit modal
- Show aspect icon and countdown timer on task cards
- Enlarge mobile menu icons for better touch targets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a65936fe4c83259dafc67390b445be