### PR TITLE
Revamp stats menu and survey questions

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -91,28 +91,46 @@ Promise.all([
 
 function showQuestion() {
   const key = aspectKeys[currentIndex];
-  document.getElementById('question-title').textContent = aspectsData[key].question;
+  const title = currentStep === 0
+    ? `Você considera ${key.toLowerCase()} importante?`
+    : `Qual o nível atual da sua ${key.toLowerCase()} hoje?`;
+  document.getElementById('question-title').textContent = title;
   aspectImage.src = aspectsData[key].image;
   aspectImage.alt = key;
-  slider.value = responses[key]?.importance || 50;
+  const value = currentStep === 0
+    ? (responses[key]?.importance || 50)
+    : (responses[key]?.level || 50);
+  slider.value = value;
   updateFeedback();
-  const progress = (currentIndex / aspectKeys.length) * 100;
+  const totalSteps = aspectKeys.length * 2;
+  const stepIndex = currentIndex * 2 + currentStep;
+  const progress = (stepIndex / totalSteps) * 100;
   document.getElementById('progress-bar').style.width = progress + '%';
 }
 
-function getFeedback(val) {
+function getImportanceFeedback(val) {
   const v = Number(val);
-  if (v <= 10) return 'Totalmente irrelevante';
-  if (v <= 25) return 'Não é importante';
-  if (v <= 50) return 'Sem prioridade';
-  if (v <= 70) return 'Relevante';
-  if (v <= 85) return 'Muito importante';
-  if (v <= 92) return 'Pilar da vida';
-  return 'Base da vida';
+  if (v <= 20) return 'Totalmente irrelevante';
+  if (v <= 40) return 'Pouco importante';
+  if (v <= 60) return 'Importância moderada';
+  if (v <= 80) return 'Importante';
+  return 'Muito importante';
+}
+
+function getLevelFeedback(val, key) {
+  const v = Number(val);
+  if (v <= 20) return `Nível de ${key} péssimo hoje`;
+  if (v <= 40) return `Nível de ${key} não está bom`;
+  if (v <= 60) return `Nível de ${key} regular`;
+  if (v <= 80) return `Nível de ${key} bom`;
+  return `Nível de ${key} excelente`;
 }
 
 function updateFeedback() {
-  sliderFeedback.textContent = getFeedback(slider.value);
+  const key = aspectKeys[currentIndex];
+  sliderFeedback.textContent = currentStep === 0
+    ? getImportanceFeedback(slider.value)
+    : getLevelFeedback(slider.value, key);
 }
 
 slider.addEventListener('input', updateFeedback);
@@ -183,7 +201,7 @@ function initApp(firstTime) {
   buildOptions();
   initTasks(aspectKeys, tasksData, aspectsData);
   initLaws(aspectKeys, lawsData, statsColors);
-  initStats(aspectKeys, responses, statsColors);
+  initStats(aspectKeys, responses, statsColors, aspectsData);
   initMindset(aspectKeys, mindsetData, statsColors);
   initHistory(aspectsData);
   scheduleNotifications();

--- a/js/stats.js
+++ b/js/stats.js
@@ -1,16 +1,18 @@
 let aspectKeys = [];
 let responses = {};
 let statsColors = {};
+let aspectsData = {};
 
 const statsSlider = document.getElementById('stats-slider');
 const statsSliderValue = document.getElementById('stats-slider-value');
 let statsIndex = 0;
 let statsResponses = {};
 
-export function initStats(keys, res, colors) {
+export function initStats(keys, res, colors, aspects) {
   aspectKeys = keys;
   responses = res;
   statsColors = colors;
+  aspectsData = aspects;
   statsSlider.addEventListener('input', () => {
     statsSliderValue.textContent = statsSlider.value;
   });
@@ -35,29 +37,20 @@ function buildStats() {
   const container = document.getElementById('stats-content');
   container.innerHTML = '';
   aspectKeys.forEach(k => {
-    const box = document.createElement('div');
-    box.className = 'stats-box';
+    const item = document.createElement('div');
+    item.className = 'stats-item';
 
-    const title = document.createElement('span');
-    title.className = 'stats-title';
-    title.textContent = k;
-    box.appendChild(title);
+    const img = document.createElement('img');
+    img.src = aspectsData[k].image;
+    img.alt = k;
+    item.appendChild(img);
 
-    const progress = document.createElement('div');
-    progress.className = 'stats-progress';
+    const name = document.createElement('span');
+    name.className = 'stats-name';
+    name.textContent = k;
+    item.appendChild(name);
 
-    const bar = document.createElement('div');
-    bar.className = 'stats-bar';
-    const level = responses[k]?.level || 0;
-    bar.style.width = level + '%';
-    const colors = statsColors[k];
-    if (colors) {
-      bar.style.background = `linear-gradient(to right, ${colors[0]}, ${colors[1]})`;
-    }
-    progress.appendChild(bar);
-    box.appendChild(progress);
-
-    container.appendChild(box);
+    container.appendChild(item);
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -242,6 +242,14 @@ li:hover { transform: scale(1.02); }
   height: 150px;
 }
 
+#question-title {
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 1.3;
+  text-align: center;
+}
+
 .page {
   display: none;
   padding: 80px 30px 20px;
@@ -354,36 +362,22 @@ li:hover { transform: scale(1.02); }
 
 #stats-content {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 20px;
+  justify-items: center;
   padding: 20px 0;
 }
 
-.stats-box {
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 10px;
-  padding: 15px;
+.stats-item img {
+  width: 75px;
+  height: 75px;
 }
 
-.stats-title {
+.stats-name {
   display: block;
-  margin-bottom: 10px;
-  font-weight: bold;
+  margin-top: 8px;
+  color: #ccc;
   text-align: center;
-}
-
-.stats-progress {
-  width: 100%;
-  height: 8px;
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 4px;
-  overflow: hidden;
-}
-
-.stats-bar {
-  height: 100%;
-  width: 0;
-  border-radius: 4px;
 }
 
 #task-modal {
@@ -608,7 +602,10 @@ li:hover { transform: scale(1.02); }
   h2 { font-size: 14px; }
   p, span, label, input, button, li { font-size: 11px; }
   button { font-size: 10px; padding: 7px 14px; }
-  .icone-central { display: none; }
+    .icone-central {
+      display: block;
+      margin: 60px auto 20px;
+    }
   #logo-screen #logo,
   .aspect-image { width: 210px; }
   .menu-item img,


### PR DESCRIPTION
## Summary
- Transform stats menu into a 4x3 grid of aspect icons with labels
- Add step-specific questions and feedback for importance and level sliders
- Lower central icons on mobile for better spacing

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a66064dc148325b6ad776dd39f188b