### PR TITLE
Revamp stats menu and questionnaire

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -89,18 +89,35 @@ Promise.all([
   }
 });
 
+const levelPrefixes = {
+  Ambiente: 'Meu ambiente',
+  Nutrition: 'Minha alimentação',
+  Sleep: 'Meu sono',
+  Hygiene: 'Minha higiene',
+  Emocional: 'Meu equilíbrio emocional',
+  Energia: 'Minha energia',
+  Learning: 'Meu aprendizado',
+  Exercícios: 'Meus exercícios',
+  Relationships: 'Minhas relações',
+  Financial: 'Minha vida financeira',
+  Lazer: 'Meu lazer',
+  Trabalho: 'Meu trabalho'
+};
+
 function showQuestion() {
   const key = aspectKeys[currentIndex];
-  document.getElementById('question-title').textContent = aspectsData[key].question;
+  const title = currentStep === 0 ? aspectsData[key].importanceQuestion : aspectsData[key].levelQuestion;
+  document.getElementById('question-title').textContent = title;
   aspectImage.src = aspectsData[key].image;
   aspectImage.alt = key;
-  slider.value = responses[key]?.importance || 50;
+  const val = currentStep === 0 ? (responses[key]?.importance ?? 50) : (responses[key]?.level ?? 50);
+  slider.value = val;
   updateFeedback();
   const progress = (currentIndex / aspectKeys.length) * 100;
   document.getElementById('progress-bar').style.width = progress + '%';
 }
 
-function getFeedback(val) {
+function getImportanceFeedback(val) {
   const v = Number(val);
   if (v <= 10) return 'Totalmente irrelevante';
   if (v <= 25) return 'Não é importante';
@@ -111,8 +128,20 @@ function getFeedback(val) {
   return 'Base da vida';
 }
 
+function getLevelFeedback(key, val) {
+  const prefix = levelPrefixes[key] || 'Meu estado';
+  const v = Number(val);
+  if (v <= 20) return `${prefix} está péssimo hoje`;
+  if (v <= 40) return `${prefix} não está bom`;
+  if (v <= 60) return `${prefix} está regular`;
+  if (v <= 80) return `${prefix} está bom`;
+  return `${prefix} está excelente`;
+}
+
 function updateFeedback() {
-  sliderFeedback.textContent = getFeedback(slider.value);
+  const key = aspectKeys[currentIndex];
+  const val = slider.value;
+  sliderFeedback.textContent = currentStep === 0 ? getImportanceFeedback(val) : getLevelFeedback(key, val);
 }
 
 slider.addEventListener('input', updateFeedback);
@@ -183,7 +212,7 @@ function initApp(firstTime) {
   buildOptions();
   initTasks(aspectKeys, tasksData, aspectsData);
   initLaws(aspectKeys, lawsData, statsColors);
-  initStats(aspectKeys, responses, statsColors);
+  initStats(aspectKeys, responses, statsColors, aspectsData);
   initMindset(aspectKeys, mindsetData, statsColors);
   initHistory(aspectsData);
   scheduleNotifications();

--- a/js/stats.js
+++ b/js/stats.js
@@ -1,16 +1,18 @@
 let aspectKeys = [];
 let responses = {};
 let statsColors = {};
+let aspectsData = {};
 
 const statsSlider = document.getElementById('stats-slider');
 const statsSliderValue = document.getElementById('stats-slider-value');
 let statsIndex = 0;
 let statsResponses = {};
 
-export function initStats(keys, res, colors) {
+export function initStats(keys, res, colors, data) {
   aspectKeys = keys;
   responses = res;
   statsColors = colors;
+  aspectsData = data;
   statsSlider.addEventListener('input', () => {
     statsSliderValue.textContent = statsSlider.value;
   });
@@ -35,29 +37,16 @@ function buildStats() {
   const container = document.getElementById('stats-content');
   container.innerHTML = '';
   aspectKeys.forEach(k => {
-    const box = document.createElement('div');
-    box.className = 'stats-box';
-
+    const item = document.createElement('div');
+    item.className = 'stats-icon';
+    const img = document.createElement('img');
+    img.src = aspectsData[k]?.image || '';
+    img.alt = k;
+    item.appendChild(img);
     const title = document.createElement('span');
-    title.className = 'stats-title';
     title.textContent = k;
-    box.appendChild(title);
-
-    const progress = document.createElement('div');
-    progress.className = 'stats-progress';
-
-    const bar = document.createElement('div');
-    bar.className = 'stats-bar';
-    const level = responses[k]?.level || 0;
-    bar.style.width = level + '%';
-    const colors = statsColors[k];
-    if (colors) {
-      bar.style.background = `linear-gradient(to right, ${colors[0]}, ${colors[1]})`;
-    }
-    progress.appendChild(bar);
-    box.appendChild(progress);
-
-    container.appendChild(box);
+    item.appendChild(title);
+    container.appendChild(item);
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -68,6 +68,14 @@ h2 {
   margin-top: 30px;
 }
 
+#question-title {
+  font-family: 'Open Sans', sans-serif;
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 1.3;
+  text-align: center;
+}
+
 p, span, label, input, button, li {
   font-size: 18px;
   line-height: 1.6;
@@ -102,6 +110,10 @@ select {
 @media (max-width: 600px) {
   select {
     height: 25px;
+  }
+
+  .icone-central {
+    margin-top: 60px;
   }
 }
 
@@ -354,36 +366,27 @@ li:hover { transform: scale(1.02); }
 
 #stats-content {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 20px;
   padding: 20px 0;
+  justify-items: center;
 }
 
-.stats-box {
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 10px;
-  padding: 15px;
+.stats-icon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
-.stats-title {
-  display: block;
-  margin-bottom: 10px;
-  font-weight: bold;
+.stats-icon img {
+  width: 75px;
+  height: 75px;
+}
+
+.stats-icon span {
+  margin-top: 8px;
+  color: #ccc;
   text-align: center;
-}
-
-.stats-progress {
-  width: 100%;
-  height: 8px;
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 4px;
-  overflow: hidden;
-}
-
-.stats-bar {
-  height: 100%;
-  width: 0;
-  border-radius: 4px;
 }
 
 #task-modal {


### PR DESCRIPTION
## Summary
- Replace stats view with a grid of 12 aspect icons.
- Style questions with Open Sans and add aspect-specific feedback for importance and level.
- Move central app icons 60px lower on mobile for better spacing.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a66064dc148325b6ad776dd39f188b