### PR TITLE
Refine layout, calendar, and theme support

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Presidencial</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body class="dark">
+<body class="black">
   <div id="logo-screen" class="center">
     <img src="logo.png" alt="Logo" id="logo" />
     <p id="logo-text" class="hidden">Construa a si mesmo</p>
@@ -52,7 +52,6 @@
       </div>
     </section>
     <section id="tasks" class="page">
-      <img src="acoes.png" alt="Tarefas" class="icone-central" />
       <div id="tasks-tabs">
         <div id="tasks-content">
           <div id="tasks-hub">
@@ -79,7 +78,6 @@
       </div>
     </section>
     <section id="laws" class="page">
-      <img src="leis.png" alt="Leis" class="icone-central" />
       <div id="laws-hub">
         <button id="add-law-btn">Nova lei</button>
         <button id="suggest-law-btn">Ver ideias</button>
@@ -87,11 +85,9 @@
       <div id="laws-list"></div>
     </section>
     <section id="stats" class="page">
-      <img src="estatisticas.png" alt="Estatísticas" class="icone-central" />
       <div id="stats-content"></div>
     </section>
     <section id="mindset" class="page">
-      <img src="mindset.png" alt="Mindset" class="icone-central" />
       <div id="mindset-hub">
         <button id="add-mindset-btn">Criar mindset</button>
         <button id="suggest-mindset-btn">Ver ideias</button>
@@ -105,7 +101,6 @@
       </div>
     </section>
     <section id="options" class="page">
-      <img src="constituicao.png" alt="Opções" class="icone-central" />
       <div id="options-content"></div>
     </section>
   </main>

--- a/js/history.js
+++ b/js/history.js
@@ -42,7 +42,7 @@ export function buildCalendar() {
   const now = new Date();
   const start = calendarStart;
   const periodInfo = getPeriodInfo(start.getHours());
-  calendarTitle.textContent = `${formatDate(start)} (${periodInfo.label})`;
+  calendarTitle.textContent = formatDate(start);
   const tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
   const periodEnd = new Date(start.getTime() + 6 * 60 * 60 * 1000);
   const periodTasks = tasks
@@ -59,7 +59,6 @@ export function buildCalendar() {
     const label = `${String(blockTime.getHours()).padStart(2, '0')}:${String(blockTime.getMinutes()).padStart(2, '0')}`;
     const boxtime = document.createElement('div');
     boxtime.className = `boxtime ${periodInfo.className}`;
-    if (blockTime < now) boxtime.classList.add('past');
     const timeDiv = document.createElement('div');
     timeDiv.className = 'boxtime-time';
     timeDiv.textContent = label;
@@ -68,6 +67,7 @@ export function buildCalendar() {
     icons.className = 'boxtime-icons';
     const blockStart = blockTime.getTime();
     const blockEnd = blockStart + 15 * 60000;
+    if (blockEnd <= now.getTime()) boxtime.classList.add('past');
     const matching = periodTasks.filter(t => {
       const tStart = new Date(t.startTime).getTime();
       const tEnd = tStart + (t.duration || 15) * 60000;
@@ -100,15 +100,24 @@ function getCurrentPeriodStart(now) {
 }
 
 function getPeriodInfo(hour) {
-  if (hour < 6) return { label: 'Madrugada', className: 'dawn' };
-  if (hour < 12) return { label: 'Manhã', className: 'morning' };
-  if (hour < 18) return { label: 'Tarde', className: 'afternoon' };
-  return { label: 'Noite', className: 'night' };
+  if (hour < 6) return { className: 'dawn' };
+  if (hour < 12) return { className: 'morning' };
+  if (hour < 18) return { className: 'afternoon' };
+  return { className: 'night' };
 }
 
 function formatDate(date) {
-  const dd = String(date.getDate()).padStart(2, '0');
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const yy = String(date.getFullYear()).slice(-2);
-  return `${dd}|${mm}|${yy}`;
+  const today = new Date();
+  const tomorrow = new Date();
+  tomorrow.setDate(today.getDate() + 1);
+  if (isSameDate(date, today)) return 'Hoje';
+  if (isSameDate(date, tomorrow)) return 'Amanhã';
+  const months = ['janeiro','fevereiro','março','abril','maio','junho','julho','agosto','setembro','outubro','novembro','dezembro'];
+  return `${date.getDate()} de ${months[date.getMonth()]} de ${date.getFullYear()}`;
+}
+
+function isSameDate(a, b) {
+  return a.getFullYear() === b.getFullYear() &&
+         a.getMonth() === b.getMonth() &&
+         a.getDate() === b.getDate();
 }

--- a/js/main.js
+++ b/js/main.js
@@ -29,6 +29,11 @@ const statsColors = {
   Trabalho: ['#ffffff', '#f5f5f5']
 };
 
+const storedAspectColors = JSON.parse(localStorage.getItem('aspectColors') || '{}');
+Object.keys(storedAspectColors).forEach(k => {
+  statsColors[k] = [storedAspectColors[k], storedAspectColors[k]];
+});
+
 // Prevent copying, context menu, and zoom interactions
 document.addEventListener('contextmenu', e => e.preventDefault());
 document.addEventListener('copy', e => e.preventDefault());
@@ -52,7 +57,10 @@ const aspectImage = document.getElementById('aspect-image');
 const headerLogo = document.getElementById('header-logo');
 const menuCarousel = document.getElementById('menu-carousel');
 
-document.body.classList.add('dark');
+let savedTheme = localStorage.getItem('theme') || 'black';
+document.body.classList.add(savedTheme);
+const savedBg = localStorage.getItem('customBg');
+if (savedBg) document.body.style.backgroundImage = `url(${savedBg})`;
 headerLogo.addEventListener('click', () => showPage('menu'));
 
 Promise.all([
@@ -214,9 +222,76 @@ function initApp(firstTime) {
   }
 }
 
+function applyTheme(theme) {
+  document.body.classList.remove('black', 'turquoise', 'whitecolor', 'minimalist');
+  document.body.classList.add(theme);
+  localStorage.setItem('theme', theme);
+  savedTheme = theme;
+}
+
 function buildOptions() {
   const container = document.getElementById('options-content');
   container.innerHTML = '';
+
+  const themeDiv = document.createElement('div');
+  const themeLabel = document.createElement('label');
+  themeLabel.textContent = 'Tema:';
+  const themeSelect = document.createElement('select');
+  [
+    { value: 'black', label: 'Black' },
+    { value: 'turquoise', label: 'Blue Turquesa' },
+    { value: 'whitecolor', label: 'White and Color' },
+    { value: 'minimalist', label: 'Minimalist' }
+  ].forEach(t => {
+    const opt = document.createElement('option');
+    opt.value = t.value;
+    opt.textContent = t.label;
+    themeSelect.appendChild(opt);
+  });
+  themeSelect.value = savedTheme;
+  themeSelect.addEventListener('change', e => applyTheme(e.target.value));
+  themeDiv.appendChild(themeLabel);
+  themeDiv.appendChild(themeSelect);
+  container.appendChild(themeDiv);
+
+  const bgDiv = document.createElement('div');
+  const bgLabel = document.createElement('label');
+  bgLabel.textContent = 'Imagem de fundo:';
+  const bgInput = document.createElement('input');
+  bgInput.type = 'file';
+  bgInput.accept = 'image/*';
+  bgInput.addEventListener('change', e => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      localStorage.setItem('customBg', reader.result);
+      document.body.style.backgroundImage = `url(${reader.result})`;
+    };
+    reader.readAsDataURL(file);
+  });
+  bgDiv.appendChild(bgLabel);
+  bgDiv.appendChild(bgInput);
+  container.appendChild(bgDiv);
+
+  const aspectColors = JSON.parse(localStorage.getItem('aspectColors') || '{}');
+  aspectKeys.forEach(k => {
+    const colorWrap = document.createElement('div');
+    const colorLabel = document.createElement('label');
+    colorLabel.textContent = `${k} cor:`;
+    const colorInput = document.createElement('input');
+    colorInput.type = 'color';
+    colorInput.value = aspectColors[k] || '#ffffff';
+    colorInput.addEventListener('input', e => {
+      aspectColors[k] = e.target.value;
+      statsColors[k] = [e.target.value, e.target.value];
+      localStorage.setItem('aspectColors', JSON.stringify(aspectColors));
+    });
+    colorWrap.appendChild(colorLabel);
+    colorWrap.appendChild(colorInput);
+    container.appendChild(colorWrap);
+  });
+
   const categories = [
     { title: 'Princípios fundamentais', filter: v => v === 10 },
     { title: 'Pilares de uma vida equilibrada', filter: v => v >= 8 && v <= 9 },

--- a/styles.css
+++ b/styles.css
@@ -19,7 +19,7 @@
   font-style: normal;
 }
 
-.dark {
+.black {
   --bg-color: #222;
   --text-color: #eee;
   --button-bg: #555;
@@ -28,6 +28,43 @@
   --header-text: #eee;
   --dropdown-bg: #111;
   --dropdown-hover-bg: #222;
+}
+
+.turquoise {
+  --bg-color: #40E0D0;
+  --text-color: #000;
+  --button-bg: #2aa198;
+  --button-hover-bg: #3fd0d0;
+  --header-bg: linear-gradient(to bottom, #5f9ea0, #40E0D0);
+  --header-text: #000;
+  --dropdown-bg: rgba(0,0,0,0.2);
+  --dropdown-hover-bg: rgba(0,0,0,0.3);
+}
+
+.whitecolor {
+  --bg-color: #ffffff;
+  --text-color: #000;
+  --button-bg: #dddddd;
+  --button-hover-bg: #cccccc;
+  --header-bg: linear-gradient(to bottom, #f0f0f0, #dddddd);
+  --header-text: #000;
+  --dropdown-bg: #ffffff;
+  --dropdown-hover-bg: #eeeeee;
+}
+
+.minimalist {
+  --bg-color: #f5f5f5;
+  --text-color: #000;
+  --button-bg: #bbbbbb;
+  --button-hover-bg: #aaaaaa;
+  --header-bg: linear-gradient(to bottom, #e0e0e0, #bbbbbb);
+  --header-text: #000;
+  --dropdown-bg: #ffffff;
+  --dropdown-hover-bg: #eeeeee;
+}
+
+.minimalist img {
+  filter: grayscale(100%);
 }
 
 body {
@@ -143,6 +180,7 @@ li:hover { transform: scale(1.02); }
   top: 0;
   left: 0;
   width: 100%;
+  padding-top: 50px;
   z-index: 1000;
 }
 
@@ -156,6 +194,10 @@ li:hover { transform: scale(1.02); }
 
 .header-logo {
   height: 40px;
+}
+
+#main-content {
+  margin-top: 100px;
 }
 
 #logo-screen #logo {
@@ -366,6 +408,7 @@ li:hover { transform: scale(1.02); }
   gap: 20px;
   justify-items: center;
   padding: 20px 0;
+  margin: 0 auto;
 }
 
 .stats-item img {
@@ -378,6 +421,18 @@ li:hover { transform: scale(1.02); }
   margin-top: 8px;
   color: #ccc;
   text-align: center;
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 700;
+}
+
+@media (min-width: 601px) {
+  .boxtime {
+    max-width: 624px;
+  }
+  .stats-item img {
+    width: 131px;
+    height: 131px;
+  }
 }
 
 #task-modal {
@@ -544,8 +599,9 @@ li:hover { transform: scale(1.02); }
   justify-content: flex-start;
   width: 100%;
   max-width: 520px;
-  padding: 5px 15px;
+  padding: 6.5px 15px;
   border-radius: 8px;
+  min-height: 39px;
 }
 .boxtime-time {
   font-size: 32px;
@@ -562,7 +618,12 @@ li:hover { transform: scale(1.02); }
   height: 30px;
 }
 .boxtime.past {
-  opacity: 0.4;
+  background: linear-gradient(to right, #cccccc, #ffffff);
+  color: #000;
+}
+
+.boxtime.past .boxtime-time {
+  color: rgba(0,0,0,0.75);
 }
 .boxtime.morning {
   background: linear-gradient(to right, #40E0D0, #ffffff);
@@ -575,6 +636,10 @@ li:hover { transform: scale(1.02); }
 }
 .boxtime.dawn {
   background: linear-gradient(to right, #000000, #000030);
+}
+
+#calendar {
+  margin-top: 50px;
 }
 
 .accept-btn {


### PR DESCRIPTION
## Summary
- Remove extra center icons, shift header logo and expand scheduling blocks
- Format history dates with Hoje/Amanhã and gray out finished times
- Add theme/background options and enlarge desktop stats icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a665ac76e8832584066aee83c1ecc7