### PR TITLE
Revamp layout, colors, and icon displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,12 +33,6 @@
     <button id="start-btn" disabled>Continuar</button>
   </div>
 
-  <header id="main-header" class="hidden">
-    <div class="header-container">
-      <img src="logo.png" alt="Logo" class="header-logo" id="header-logo" />
-    </div>
-  </header>
-
   <main id="main-content" class="hidden">
     <div id="menu-carousel" class="menu-carousel"></div>
     <section id="menu" class="page active">

--- a/js/laws.js
+++ b/js/laws.js
@@ -1,6 +1,7 @@
 let aspectKeys = [];
 let lawsData = [];
 let statsColors = {};
+let aspectsData = {};
 
 const addLawBtn = document.getElementById('add-law-btn');
 const suggestLawBtn = document.getElementById('suggest-law-btn');
@@ -16,10 +17,11 @@ const lawActionModal = document.getElementById('law-action-modal');
 const revokeLawBtn = document.getElementById('revoke-law');
 const cancelLawActionBtn = document.getElementById('cancel-law-action');
 
-export function initLaws(keys, data, colors) {
+export function initLaws(keys, data, colors, aspects) {
   aspectKeys = keys;
   lawsData = data;
   statsColors = colors;
+  aspectsData = aspects;
   addLawBtn.addEventListener('click', () => openLawModal());
   suggestLawBtn.addEventListener('click', suggestLaw);
   saveLawBtn.addEventListener('click', saveLaw);
@@ -58,12 +60,14 @@ function buildLaws() {
     div.className = 'law-box';
     const colors = statsColors[l.aspect] || ['#555', '#777'];
     div.style.background = `linear-gradient(135deg, ${colors[0]}, ${colors[1]})`;
+    const img = document.createElement('img');
+    img.src = aspectsData[l.aspect].image;
+    img.alt = l.aspect;
+    img.className = 'law-aspect-icon';
+    div.appendChild(img);
     const h3 = document.createElement('h3');
     h3.textContent = l.title;
-    const p = document.createElement('p');
-    p.textContent = l.description;
     div.appendChild(h3);
-    div.appendChild(p);
     div.dataset.index = index;
     let pressTimer;
     const start = () => { pressTimer = setTimeout(() => openLawActionModal(index), 500); };

--- a/js/main.js
+++ b/js/main.js
@@ -15,18 +15,18 @@ let responses = JSON.parse(localStorage.getItem('responses') || '{}');
 let previousLogin = 0;
 
 const statsColors = {
-  Exercícios: ['#ff4d4d', '#ff6666'],
-  Relationships: ['#ffd700', '#ffea00'],
-  Nutrition: ['#66bb6a', '#81c784'],
-  Sleep: ['#003366', '#004080'],
-  Ambiente: ['#00bcd4', '#26c6da'],
-  Emocional: ['#64b5f6', '#90caf9'],
-  Hygiene: ['#b3e5fc', '#e1f5fe'],
-  Energia: ['#c0c0c0', '#d3d3d3'],
-  Learning: ['#ffb300', '#ffca28'],
-  Financial: ['#2e7d32', '#388e3c'],
-  Lazer: ['#7e57c2', '#9575cd'],
-  Trabalho: ['#ffffff', '#f5f5f5']
+  Ambiente: ['#224F87', '#4885CF'],
+  Nutrition: ['#B34B14', '#D4642C'],
+  Sleep: ['#B34B14', '#1C3873'],
+  Hygiene: ['#1486B8', '#60C1EB'],
+  Emocional: ['#1486B8', '#83BDC9'],
+  Energia: ['#BA4A0F', '#0B0E52'],
+  Learning: ['#0E0338', '#245085'],
+  Exercícios: ['#82090F', '#C24A00'],
+  Relationships: ['#82090F', '#6B0641'],
+  Financial: ['#125E2D', '#0FA841'],
+  Lazer: ['#125E2D', '#5D0BA3'],
+  Trabalho: ['#000000', '#363675']
 };
 
 const storedAspectColors = JSON.parse(localStorage.getItem('aspectColors') || '{}');
@@ -54,14 +54,12 @@ document.addEventListener('keydown', e => {
 const slider = document.getElementById('slider');
 const sliderFeedback = document.getElementById('slider-feedback');
 const aspectImage = document.getElementById('aspect-image');
-const headerLogo = document.getElementById('header-logo');
 const menuCarousel = document.getElementById('menu-carousel');
 
 let savedTheme = localStorage.getItem('theme') || 'black';
 document.body.classList.add(savedTheme);
 const savedBg = localStorage.getItem('customBg');
 if (savedBg) document.body.style.backgroundImage = `url(${savedBg})`;
-headerLogo.addEventListener('click', () => showPage('menu'));
 
 Promise.all([
   fetch('data/aspects.json').then(r => r.json()),
@@ -76,7 +74,6 @@ Promise.all([
   aspectKeys = Object.keys(aspects);
   if (Object.keys(responses).length) {
     document.getElementById('logo-screen').style.display = 'none';
-    document.getElementById('main-header').classList.remove('hidden');
     document.getElementById('main-content').classList.remove('hidden');
     initApp(false);
   } else {
@@ -208,12 +205,11 @@ function initApp(firstTime) {
   }
   buildOptions();
   initTasks(aspectKeys, tasksData, aspectsData);
-  initLaws(aspectKeys, lawsData, statsColors);
+  initLaws(aspectKeys, lawsData, statsColors, aspectsData);
   initStats(aspectKeys, responses, statsColors, aspectsData);
-  initMindset(aspectKeys, mindsetData, statsColors);
+  initMindset(aspectKeys, mindsetData, statsColors, aspectsData);
   initHistory(aspectsData);
   scheduleNotifications();
-  document.getElementById('main-header').classList.remove('hidden');
   document.getElementById('main-content').classList.remove('hidden');
   setInterval(checkStatsPrompt, 60000);
   checkStatsPrompt();

--- a/js/mindset.js
+++ b/js/mindset.js
@@ -1,6 +1,7 @@
 let aspectKeys = [];
 let mindsetData = [];
 let statsColors = {};
+let aspectsData = {};
 let editingMindsetIndex = null;
 
 const addMindsetBtn = document.getElementById('add-mindset-btn');
@@ -17,10 +18,11 @@ const declineMindsetBtn = document.getElementById('decline-mindset');
 const cancelMindsetBtn = document.getElementById('cancel-mindset');
 const deleteMindsetBtn = document.getElementById('delete-mindset');
 
-export function initMindset(keys, data, colors) {
+export function initMindset(keys, data, colors, aspects) {
   aspectKeys = keys;
   mindsetData = data;
   statsColors = colors;
+  aspectsData = aspects;
   mindsetRateInput.addEventListener('input', () => {
     mindsetRateValue.textContent = mindsetRateInput.value;
   });
@@ -54,12 +56,14 @@ function buildMindset() {
     div.className = 'mindset-box';
     const colors = statsColors[m.aspect] || ['#555', '#777'];
     div.style.background = `linear-gradient(135deg, ${colors[0]}, ${colors[1]})`;
+    const img = document.createElement('img');
+    img.src = aspectsData[m.aspect].image;
+    img.alt = m.aspect;
+    img.className = 'mindset-aspect-icon';
+    div.appendChild(img);
     const h3 = document.createElement('h3');
     h3.textContent = m.title;
-    const p = document.createElement('p');
-    p.textContent = m.description;
     div.appendChild(h3);
-    div.appendChild(p);
     let pressTimer;
     div.addEventListener('dblclick', () => openMindsetModal(idx, m));
     div.addEventListener('touchstart', () => {

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -282,7 +282,7 @@ function suggestTask() {
   const tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
   const now = new Date(Date.now() + 3600000).toISOString();
   tasks.push({
-    title: idea.title.slice(0, 14),
+    title: idea.title.slice(0, 27),
     description: (idea.description || '').slice(0, 60),
     startTime: now,
     aspect: idea.aspect,
@@ -359,7 +359,7 @@ function saveTask() {
       return;
     }
     const baseTask = {
-      title: title.slice(0, 14),
+      title: title.slice(0, 27),
       description: description.slice(0, 60),
       aspect,
       type,
@@ -410,7 +410,7 @@ function saveTask() {
     }
   } else {
     const taskObj = {
-      title: title.slice(0, 14),
+      title: title.slice(0, 27),
       description: (description || '').slice(0, 60),
       aspect,
       type,

--- a/styles.css
+++ b/styles.css
@@ -173,31 +173,8 @@ li:hover { transform: scale(1.02); }
   transition: opacity 1s ease;
 }
 
-#main-header {
-  background: var(--header-bg);
-  color: var(--header-text);
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  padding-top: 50px;
-  z-index: 1000;
-}
-
-.header-container {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px 30px;
-  position: relative;
-}
-
-.header-logo {
-  height: 40px;
-}
-
 #main-content {
-  margin-top: 100px;
+  margin-top: 20px;
 }
 
 #logo-screen #logo {
@@ -414,6 +391,7 @@ li:hover { transform: scale(1.02); }
 .stats-item img {
   width: 75px;
   height: 75px;
+  margin-top: -30px;
 }
 
 .stats-name {
@@ -432,6 +410,7 @@ li:hover { transform: scale(1.02); }
   .stats-item img {
     width: 131px;
     height: 131px;
+    margin-top: -30px;
   }
 }
 
@@ -549,6 +528,20 @@ li:hover { transform: scale(1.02); }
   margin-bottom: 10px;
   border-radius: 8px;
   color: #fff;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.law-aspect-icon,
+.mindset-aspect-icon {
+  width: 24px;
+  height: 24px;
+}
+
+.law-box h3,
+.mindset-box h3 {
+  margin: 0;
 }
 
 #tasks-tabs {
@@ -675,9 +668,6 @@ li:hover { transform: scale(1.02); }
   .aspect-image { width: 210px; }
   .menu-item img,
   .menu-carousel img { width: 140px; height: 140px; }
-  #main-header { height: 42px; }
-  .header-container { padding: 7px 30px; }
-  .header-logo { height: 28px; }
   #slider, #stats-slider { width: 210px; }
   .progress-container { height: 6px; }
   #progress-bar { border-radius: 3px; }


### PR DESCRIPTION
## Summary
- Remove main header and adjust layout spacing
- Refresh aspect color palette and shift stats icons upward
- Show aspect icons alongside law and mindset titles; extend task title length

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a67baaceb883259887e4fad856511d