### PR TITLE
feat: add turquoise neon theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Presidencial</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body class="black">
+<body class="turquoise">
   <div id="logo-screen" class="center">
     <img src="logo.png" alt="Logo" id="logo" />
     <p id="logo-text" class="hidden">Construa a si mesmo</p>

--- a/js/main.js
+++ b/js/main.js
@@ -132,18 +132,18 @@ const levelMessages = {
 
 
 const statsColors = {
-  Emocional: ['#64b5f6', '#90caf9'],
-  Energia: ['#c0c0c0', '#d3d3d3'],
-  Relacionamentos: ['#ffd700', '#ffea00'],
-  Propósito: ['#7e57c2', '#9575cd'],
-  Nutrição: ['#66bb6a', '#81c784'],
-  Sono: ['#003366', '#004080'],
-  Higiene: ['#b3e5fc', '#e1f5fe'],
-  Exercícios: ['#ff4d4d', '#ff6666'],
-  Trabalho: ['#ffffff', '#f5f5f5'],
-  Financeiro: ['#2e7d32', '#388e3c'],
-  Estudo: ['#ffb300', '#ffca28'],
-  Ambiente: ['#00bcd4', '#26c6da']
+  Emocional: ['#000000', '#40e0d0'],
+  Energia: ['#000000', '#40e0d0'],
+  Relacionamentos: ['#000000', '#40e0d0'],
+  Propósito: ['#000000', '#40e0d0'],
+  Nutrição: ['#000000', '#40e0d0'],
+  Sono: ['#000000', '#40e0d0'],
+  Higiene: ['#000000', '#40e0d0'],
+  Exercícios: ['#000000', '#40e0d0'],
+  Trabalho: ['#000000', '#40e0d0'],
+  Financeiro: ['#000000', '#40e0d0'],
+  Estudo: ['#000000', '#40e0d0'],
+  Ambiente: ['#000000', '#40e0d0']
 };
 
 const storedAspectColors = JSON.parse(localStorage.getItem('aspectColors') || '{}');

--- a/styles.css
+++ b/styles.css
@@ -48,6 +48,35 @@ body.neon {
   color: var(--text-color);
 }
 
+/* Azul Turquesa neon theme */
+.turquoise {
+  --bg-color: #000;
+  --text-color: #e0ffff;
+  --button-bg: #004d4d;
+  --button-hover-bg: #008080;
+  --header-bg: linear-gradient(180deg, #000, #002222);
+  --header-text: #40e0d0;
+  --dropdown-bg: rgba(0,32,32,0.85);
+  --dropdown-hover-bg: rgba(0,48,48,0.76);
+}
+
+body.turquoise {
+  background: linear-gradient(180deg, #000, #001010);
+  color: var(--text-color);
+}
+
+body.turquoise * {
+  outline: 1px solid #40e0d0;
+  box-shadow: 0 0 6px #40e0d0;
+  transition: box-shadow 0.3s ease-in-out;
+  animation: neonPulse 2s ease-in-out infinite alternate;
+}
+
+@keyframes neonPulse {
+  from { box-shadow: 0 0 4px #40e0d0; }
+  to   { box-shadow: 0 0 12px #40e0d0; }
+}
+
 .whitecolor {
   --bg-color: #ffffff;
   --text-color: #000;
@@ -330,15 +359,15 @@ li:hover { transform: scale(1.02); }
 }
 
 .task-item.pending {
-    background: linear-gradient(135deg, #00A2E8, #33B8FF);
+    background: linear-gradient(135deg, #000000, #40e0d0);
 }
 
 .task-item.overdue {
-  background: linear-gradient(135deg, #FF5F6D, #FFC371);
+  background: linear-gradient(135deg, #000000, #40e0d0);
 }
 
 .task-item.completed {
-    background: linear-gradient(135deg, #44B816, #6CD932);
+    background: linear-gradient(135deg, #000000, #40e0d0);
 }
 
 .task-item h3 {
@@ -494,7 +523,7 @@ li:hover { transform: scale(1.02); }
 }
 
 .task-form {
-  background: linear-gradient(135deg, #5ef0ff, #7a5cff);
+  background: linear-gradient(135deg, #000000, #40e0d0);
   color: #fff;
   padding: 20px;
   border-radius: 8px;
@@ -519,7 +548,7 @@ li:hover { transform: scale(1.02); }
   padding: 8px;
   border: none;
   border-radius: 4px;
-  background: #7a5cff;
+  background: #004d4d;
   color: #fff;
 }
 
@@ -528,12 +557,12 @@ li:hover { transform: scale(1.02); }
 }
 
 #save-task {
-  background: linear-gradient(135deg, #00ff7f, #32cd32);
+  background: linear-gradient(135deg, #000000, #40e0d0);
   color: #fff;
 }
 
 #cancel-task {
-  background: linear-gradient(135deg, #ff6347, #ff0000);
+  background: linear-gradient(135deg, #000000, #40e0d0);
   color: #fff;
 }
 
@@ -620,6 +649,8 @@ li:hover { transform: scale(1.02); }
   padding: 6.5px 15px;
   border-radius: 8px;
   min-height: 39px;
+  background: linear-gradient(to right, #000000, #40e0d0);
+  color: #fff;
 }
 .boxtime-time {
   font-size: 32px;
@@ -635,25 +666,17 @@ li:hover { transform: scale(1.02); }
   width: 30px;
   height: 30px;
 }
-.boxtime.past {
-  background: linear-gradient(to right, #cccccc, #ffffff);
-  color: #000;
+.boxtime.past,
+.boxtime.morning,
+.boxtime.afternoon,
+.boxtime.night,
+.boxtime.dawn {
+  background: linear-gradient(to right, #000000, #40e0d0);
+  color: #fff;
 }
 
 .boxtime.past .boxtime-time {
-  color: rgba(0,0,0,0.75);
-}
-.boxtime.morning {
-  background: linear-gradient(to right, #5ef0ff, #ffffff);
-}
-.boxtime.afternoon {
-  background: linear-gradient(to right, #ff5cc8, #5ef0ff);
-}
-.boxtime.night {
-  background: linear-gradient(to right, #140b1f, #0b0f1a);
-}
-.boxtime.dawn {
-  background: linear-gradient(to right, #0b0f1a, #1b1140);
+  color: rgba(255, 255, 255, 0.75);
 }
 
 #calendar {


### PR DESCRIPTION
## Summary
- add a new turquoise neon theme with global animated borders
- unify aspect color gradients to black-to-turquoise
- switch default HTML theme to turquoise

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4866cf84832588cfe4e8ffcfa9e6