### PR TITLE
Fix history calendar layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,9 +99,9 @@
       <div id="mindset-content"></div>
     </section>
     <section id="history" class="page">
-      <div id="calendar">
+      <div id="history-calendar">
         <h2 id="calendar-title"></h2>
-        <div id="calendar-list"></div>
+        <div id="history-calendar-list"></div>
       </div>
     </section>
     <section id="options" class="page">

--- a/js/history.js
+++ b/js/history.js
@@ -9,7 +9,7 @@ let titleTouchX = 0;
 export function initHistory(aspects) {
   aspectsMap = aspects;
   calendarTitle = document.getElementById('calendar-title');
-  calendarList = document.getElementById('calendar-list');
+  calendarList = document.getElementById('history-calendar-list');
   if (calendarTitle) {
     calendarTitle.addEventListener('touchstart', e => {
       titleTouchX = e.touches[0].clientX;

--- a/styles.css
+++ b/styles.css
@@ -635,11 +635,11 @@ li:hover { transform: scale(1.02); }
   overflow: hidden;
 }
 #tasks-content,
-#calendar {
+#tasks #calendar {
   width: 100%;
   transition: transform 0.3s ease;
 }
-#calendar {
+#tasks #calendar {
   position: absolute;
   top: 100%;
   left: 0;
@@ -653,6 +653,14 @@ li:hover { transform: scale(1.02); }
 #tasks.show-calendar #calendar {
   transform: translateY(-100%);
 }
+#history-calendar {
+  position: relative;
+  top: auto;
+  left: auto;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
 #calendar-title {
   height: 60px;
   width: 100%;
@@ -663,7 +671,7 @@ li:hover { transform: scale(1.02); }
   font-family: 'Lato', sans-serif;
   font-size: 20px;
 }
-#calendar-list {
+#history-calendar-list {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -710,7 +718,7 @@ li:hover { transform: scale(1.02); }
   color: rgba(255, 255, 255, 0.75);
 }
 
-#calendar {
+#history-calendar {
   margin-top: 0;
 }
 


### PR DESCRIPTION
## Summary
- rename calendar elements to history-calendar variants
- scope calendar styles to tasks and add dedicated history calendar block
- update history.js to target new IDs

## Testing
- `node --check js/history.js`
- `node --check js/tasks.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac8945f7148325ab595bdf76f99bb9