### PR TITLE
Revamp statistics stats section with carousel

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -15,6 +15,7 @@ let previousLogin = 0;
 let pendingReturnPage = null;
 let suppressVoting = false;
 let introDone = localStorage.getItem('introDone') === 'true';
+let levelVotingDone = localStorage.getItem('levelVotingDone') === 'true';
 
 const introMattersMessages = [
   'Este é o iLife Prime\nEstamos preparando tudo pra você',
@@ -388,6 +389,8 @@ document.getElementById('next-btn').addEventListener('click', () => {
       showQuestion();
     } else {
       localStorage.setItem('responses', JSON.stringify(responses));
+      localStorage.setItem('levelVotingDone', 'true');
+      levelVotingDone = true;
       document.getElementById('question-screen').classList.add('hidden');
       if (pendingReturnPage) {
         document.getElementById('main-header').classList.remove('hidden');
@@ -612,7 +615,15 @@ function showPage(pageId) {
   if (section) section.classList.add('active');
   if (!suppressVoting) {
     if (pageId === 'laws') startMattersVoting();
-    if (pageId === 'stats') startLevelVoting();
+    if (pageId === 'stats') {
+      if (!levelVotingDone) {
+        startLevelVoting();
+      } else {
+        initStats(aspectKeys, responses, statsColors, aspectsData);
+      }
+    }
+  } else if (pageId === 'stats') {
+    initStats(aspectKeys, responses, statsColors, aspectsData);
   }
 }
 

--- a/js/stats.js
+++ b/js/stats.js
@@ -1,38 +1,106 @@
-import { applyCascade } from './utils.js';
-
 let aspectKeys = [];
 let responses = {};
 let statsColors = {};
 let aspectsData = {};
+let currentIndex = 0;
+let handlersAttached = false;
+let startX = 0;
 
 export function initStats(keys, res, colors, aspects) {
   aspectKeys = keys;
   responses = res;
   statsColors = colors;
   aspectsData = aspects;
-  buildStats();
+  currentIndex = 0;
+  showCurrent();
+  if (!handlersAttached) {
+    attachHandlers();
+    handlersAttached = true;
+  }
 }
 
-function buildStats() {
+function showCurrent() {
   const container = document.getElementById('stats-content');
   container.innerHTML = '';
-  aspectKeys.forEach(k => {
-    const item = document.createElement('div');
-    item.className = 'stats-item';
+  if (!aspectKeys.length) return;
+  const key = aspectKeys[currentIndex];
+  const level = responses[key]?.level || 0;
+  const color = statsColors[key][1];
 
-    const img = document.createElement('img');
-    img.src = aspectsData[k].image;
-    img.alt = k;
-    item.appendChild(img);
+  const item = document.createElement('div');
+  item.className = 'stats-item';
 
-    const name = document.createElement('span');
-    name.className = 'stats-name';
-    name.textContent = k;
-    item.appendChild(name);
+  const circleWrap = document.createElement('div');
+  circleWrap.className = 'stats-circle';
 
-    container.appendChild(item);
+  const svgNS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(svgNS, 'svg');
+  svg.setAttribute('width', '290');
+  svg.setAttribute('height', '290');
+  const radius = 125;
+  const circumference = 2 * Math.PI * radius;
+
+  const bg = document.createElementNS(svgNS, 'circle');
+  bg.setAttribute('cx', '145');
+  bg.setAttribute('cy', '145');
+  bg.setAttribute('r', radius);
+  bg.setAttribute('stroke', '#222');
+  bg.setAttribute('stroke-width', '20');
+  bg.setAttribute('fill', 'none');
+  svg.appendChild(bg);
+
+  const prog = document.createElementNS(svgNS, 'circle');
+  prog.setAttribute('cx', '145');
+  prog.setAttribute('cy', '145');
+  prog.setAttribute('r', radius);
+  prog.setAttribute('stroke', color);
+  prog.setAttribute('stroke-width', '20');
+  prog.setAttribute('fill', 'none');
+  prog.setAttribute('stroke-linecap', 'round');
+  prog.setAttribute('stroke-dasharray', circumference);
+  prog.setAttribute('stroke-dashoffset', circumference * (1 - level / 100));
+  prog.style.filter = `drop-shadow(0 0 10px ${color})`;
+  svg.appendChild(prog);
+
+  circleWrap.appendChild(svg);
+
+  const img = document.createElement('img');
+  img.src = aspectsData[key].image;
+  img.alt = key;
+  circleWrap.appendChild(img);
+
+  item.appendChild(circleWrap);
+
+  const name = document.createElement('span');
+  name.className = 'stats-name';
+  name.textContent = `${key}: ${level}%`;
+  item.appendChild(name);
+
+  container.appendChild(item);
+}
+
+function attachHandlers() {
+  const container = document.getElementById('stats-content');
+  container.addEventListener('touchstart', e => startX = e.touches[0].clientX);
+  container.addEventListener('touchend', e => {
+    const dx = e.changedTouches[0].clientX - startX;
+    if (dx < -50) next();
+    else if (dx > 50) prev();
   });
-  applyCascade(container);
+  document.addEventListener('keydown', e => {
+    if (e.key === 'ArrowLeft') prev();
+    if (e.key === 'ArrowRight') next();
+  });
+}
+
+function next() {
+  currentIndex = (currentIndex + 1) % aspectKeys.length;
+  showCurrent();
+}
+
+function prev() {
+  currentIndex = (currentIndex - 1 + aspectKeys.length) % aspectKeys.length;
+  showCurrent();
 }
 
 export function checkStatsPrompt() {}

--- a/styles.css
+++ b/styles.css
@@ -469,22 +469,46 @@ li:hover { transform: scale(1.02); }
 }
 
 #stats-content {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 20px;
-  justify-items: center;
-  padding: 20px 0;
-  margin: -60px auto 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+  margin-top: -60px;
 }
 
-.stats-item img {
-  width: 75px;
-  height: 75px;
+.stats-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.stats-circle {
+  position: relative;
+  width: 290px;
+  height: 290px;
+}
+
+.stats-circle svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: rotate(-90deg);
+}
+
+.stats-circle img {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  width: 250px;
+  height: 250px;
+  border-radius: 50%;
 }
 
 .stats-name {
   display: block;
-  margin-top: 8px;
+  margin-top: 20px;
   color: #ccc;
   text-align: center;
   font-family: 'Open Sans', sans-serif;
@@ -494,10 +518,6 @@ li:hover { transform: scale(1.02); }
 @media (min-width: 601px) {
   .boxtime {
     max-width: 624px;
-  }
-  .stats-item img {
-    width: 131px;
-    height: 131px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Show aspect statistics in a swipeable carousel with neon progress ring
- Ask for "Nível atual" questionnaire only once and reuse results
- Center aspect icons at 250x250 with neon percentage ring

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/stats.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68acc9efdf508325978fc6cb98705c1e