### PR TITLE
Add stats carousel with single level questionnaire

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,7 @@
 import { initTasks } from './tasks.js';
 import { initLaws } from './laws.js';
 import { initMindset, openMindsetModal, suggestMindset } from './mindset.js';
-import { initStats } from './stats.js';
+import { initStats, needsLevelPrompt } from './stats.js';
 
 let aspectsData = {};
 let aspectKeys = [];
@@ -388,10 +388,12 @@ document.getElementById('next-btn').addEventListener('click', () => {
       showQuestion();
     } else {
       localStorage.setItem('responses', JSON.stringify(responses));
+      localStorage.setItem('levelDone', 'true');
       document.getElementById('question-screen').classList.add('hidden');
       if (pendingReturnPage) {
         document.getElementById('main-header').classList.remove('hidden');
         document.getElementById('main-content').classList.remove('hidden');
+        initStats(aspectKeys, responses, statsColors, aspectsData);
         suppressVoting = true;
         showPage(pendingReturnPage);
         suppressVoting = false;
@@ -612,7 +614,7 @@ function showPage(pageId) {
   if (section) section.classList.add('active');
   if (!suppressVoting) {
     if (pageId === 'laws') startMattersVoting();
-    if (pageId === 'stats') startLevelVoting();
+    if (pageId === 'stats' && needsLevelPrompt()) startLevelVoting();
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -469,36 +469,38 @@ li:hover { transform: scale(1.02); }
 }
 
 #stats-content {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 20px;
-  justify-items: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   padding: 20px 0;
-  margin: -60px auto 0;
-}
-
-.stats-item img {
-  width: 75px;
-  height: 75px;
 }
 
 .stats-name {
   display: block;
-  margin-top: 8px;
+  margin-top: 16px;
   color: #ccc;
   text-align: center;
   font-family: 'Open Sans', sans-serif;
   font-weight: 700;
 }
 
-@media (min-width: 601px) {
-  .boxtime {
-    max-width: 624px;
-  }
-  .stats-item img {
-    width: 131px;
-    height: 131px;
-  }
+.progress-ring {
+  position: relative;
+  width: 250px;
+  height: 250px;
+}
+
+.progress-ring img {
+  width: 250px;
+  height: 250px;
+  display: block;
+}
+
+.progress-ring svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: rotate(-90deg);
 }
 
 #task-modal {


### PR DESCRIPTION
## Summary
- Display stats as a swipeable carousel showing one 250px aspect icon at a time with a neon progress ring.
- Show level questionnaire only once and persist results for future visits.
- Style stats section for centered carousel layout.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acc9efdf508325978fc6cb98705c1e