### PR TITLE
Center stats items and enlarge circle

### DIFF
--- a/js/stats.js
+++ b/js/stats.js
@@ -35,26 +35,26 @@ function showCurrent() {
 
   const svgNS = 'http://www.w3.org/2000/svg';
   const svg = document.createElementNS(svgNS, 'svg');
-  svg.setAttribute('width', '290');
-  svg.setAttribute('height', '290');
-  const radius = 125;
+  svg.setAttribute('width', '392');
+  svg.setAttribute('height', '392');
+  const radius = 169;
   const circumference = 2 * Math.PI * radius;
 
   const bg = document.createElementNS(svgNS, 'circle');
-  bg.setAttribute('cx', '145');
-  bg.setAttribute('cy', '145');
+  bg.setAttribute('cx', '196');
+  bg.setAttribute('cy', '196');
   bg.setAttribute('r', radius);
   bg.setAttribute('stroke', '#222');
-  bg.setAttribute('stroke-width', '20');
+  bg.setAttribute('stroke-width', '27');
   bg.setAttribute('fill', 'none');
   svg.appendChild(bg);
 
   const prog = document.createElementNS(svgNS, 'circle');
-  prog.setAttribute('cx', '145');
-  prog.setAttribute('cy', '145');
+  prog.setAttribute('cx', '196');
+  prog.setAttribute('cy', '196');
   prog.setAttribute('r', radius);
   prog.setAttribute('stroke', color);
-  prog.setAttribute('stroke-width', '20');
+  prog.setAttribute('stroke-width', '27');
   prog.setAttribute('fill', 'none');
   prog.setAttribute('stroke-linecap', 'round');
   prog.setAttribute('stroke-dasharray', circumference);

--- a/styles.css
+++ b/styles.css
@@ -475,7 +475,18 @@ li:hover { transform: scale(1.02); }
   height: 100%;
   overflow: hidden;
   position: relative;
-  margin-top: -60px;
+  margin-top: 0;
+}
+
+#stats.page {
+  padding: 0;
+}
+
+#stats.page.active {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
 }
 
 .stats-item {
@@ -486,8 +497,8 @@ li:hover { transform: scale(1.02); }
 
 .stats-circle {
   position: relative;
-  width: 290px;
-  height: 290px;
+  width: 392px;
+  height: 392px;
 }
 
 .stats-circle svg {
@@ -499,10 +510,10 @@ li:hover { transform: scale(1.02); }
 
 .stats-circle img {
   position: absolute;
-  top: 20px;
-  left: 20px;
-  width: 250px;
-  height: 250px;
+  top: 27px;
+  left: 27px;
+  width: 338px;
+  height: 338px;
   border-radius: 50%;
 }
 


### PR DESCRIPTION
## Summary
- Centralize stats page menu elements both horizontally and vertically
- Increase statistics circle and icon by 35%

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acd08a7a388325b1bbffa380167021