### PR TITLE
Add history menu with 15-minute timeline view

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
     <section id="menu" class="page active">
       <div class="menu-grid">
         <div class="menu-item" data-page="tasks"><img src="acoes.png" alt="Tarefas" /></div>
+        <div class="menu-item" data-page="history"><img src="tarefas.png" alt="Histórico" /></div>
         <div class="menu-item" data-page="laws"><img src="leis.png" alt="Leis" /></div>
         <div class="menu-item" data-page="stats"><img src="estatisticas.png" alt="Estatísticas" /></div>
         <div class="menu-item" data-page="mindset"><img src="mindset.png" alt="Mindset" /></div>
@@ -83,6 +84,9 @@
           </div>
         </div>
       </div>
+    </section>
+    <section id="history" class="page">
+      <div id="history-grid"></div>
     </section>
     <section id="laws" class="page">
       <div id="laws-hub">

--- a/js/history.js
+++ b/js/history.js
@@ -1,0 +1,36 @@
+export function initHistory() {
+  const container = document.getElementById('history-grid');
+  if (!container) return;
+  container.innerHTML = '';
+  const today = new Date();
+  const dateStr = today.toISOString().split('T')[0];
+  const slots = [];
+  for (let h = 0; h < 24; h++) {
+    for (let m = 0; m < 60; m += 15) {
+      const idx = h * 4 + m / 15;
+      const slot = document.createElement('div');
+      slot.className = 'history-slot';
+      const time = document.createElement('span');
+      time.className = 'history-time';
+      time.textContent = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+      slot.appendChild(time);
+      container.appendChild(slot);
+      slots[idx] = slot;
+    }
+  }
+  const tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
+  tasks.forEach(t => {
+    if (!t.startTime) return;
+    const start = new Date(t.startTime);
+    const d = start.toISOString().split('T')[0];
+    if (d !== dateStr) return;
+    const idx = start.getHours() * 4 + Math.floor(start.getMinutes() / 15);
+    const slot = slots[idx];
+    if (slot) {
+      const span = document.createElement('span');
+      span.className = 'history-task';
+      span.textContent = ' ' + t.title;
+      slot.appendChild(span);
+    }
+  });
+}

--- a/js/main.js
+++ b/js/main.js
@@ -2,6 +2,7 @@ import { initTasks } from './tasks.js';
 import { initLaws } from './laws.js';
 import { initMindset, openMindsetModal, suggestMindset } from './mindset.js';
 import { initStats } from './stats.js';
+import { initHistory } from './history.js';
 
 let aspectsData = {};
 let aspectKeys = [];
@@ -449,6 +450,7 @@ function initApp(firstTime) {
   initLaws(aspectKeys, lawsData, statsColors);
   initStats(aspectKeys, responses, statsColors, aspectsData);
   initMindset(aspectKeys, mindsetData, statsColors);
+  initHistory();
   scheduleNotifications();
   document.getElementById('main-header').classList.remove('hidden');
   document.getElementById('main-content').classList.remove('hidden');
@@ -575,6 +577,7 @@ document.querySelectorAll('.menu-item').forEach(item => {
 function initCarousel() {
   const items = [
     { page: 'tasks', img: 'acoes.png', label: 'Tarefas' },
+    { page: 'history', img: 'tarefas.png', label: 'Histórico' },
     { page: 'laws', img: 'leis.png', label: 'Leis' },
     { page: 'stats', img: 'estatisticas.png', label: 'Estatísticas' },
     { page: 'mindset', img: 'mindset.png', label: 'Mindset' },
@@ -624,6 +627,9 @@ function showPage(pageId) {
     }
   } else if (pageId === 'stats') {
     initStats(aspectKeys, responses, statsColors, aspectsData);
+  }
+  if (pageId === 'history') {
+    initHistory();
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -682,6 +682,27 @@ li:hover { transform: scale(1.02); }
   background: #FFC371;
 }
 
+#history-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
+.history-slot {
+  display: flex;
+  border-bottom: 1px solid #444;
+  padding: 4px;
+  min-height: 20px;
+}
+
+.history-time {
+  width: 60px;
+  font-weight: bold;
+}
+
+.history-task {
+  margin-left: 10px;
+}
+
 @media (max-width: 600px) {
   body {
     overflow-x: hidden;


### PR DESCRIPTION
## Summary
- restore sixth menu icon for historical schedule
- show daily timeline in 15-minute blocks
- wire up navigation and carousel to include history page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acd411036c8325934e953564841702