### PR TITLE
Implement carousel stats with one-time level prompt

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -16,6 +16,7 @@ let previousLogin = 0;
 let pendingReturnPage = null;
 let suppressVoting = false;
 let introDone = localStorage.getItem('introDone') === 'true';
+let levelDone = localStorage.getItem('levelDone') === 'true';
 
 const introMattersMessages = [
   'Este é o iLife Prime\nEstamos preparando tudo pra você',
@@ -389,10 +390,13 @@ document.getElementById('next-btn').addEventListener('click', () => {
       showQuestion();
     } else {
       localStorage.setItem('responses', JSON.stringify(responses));
+      localStorage.setItem('levelDone', 'true');
+      levelDone = true;
       document.getElementById('question-screen').classList.add('hidden');
       if (pendingReturnPage) {
         document.getElementById('main-header').classList.remove('hidden');
         document.getElementById('main-content').classList.remove('hidden');
+        initStats(aspectKeys, responses, statsColors, aspectsData);
         suppressVoting = true;
         showPage(pendingReturnPage);
         suppressVoting = false;
@@ -615,7 +619,7 @@ function showPage(pageId) {
   if (section) section.classList.add('active');
   if (!suppressVoting) {
     if (pageId === 'laws') startMattersVoting();
-    if (pageId === 'stats') startLevelVoting();
+    if (pageId === 'stats' && !levelDone) startLevelVoting();
   }
 }
 

--- a/js/stats.js
+++ b/js/stats.js
@@ -1,39 +1,79 @@
-import { applyCascade } from './utils.js';
-
 let aspectKeys = [];
 let responses = {};
 let statsColors = {};
 let aspectsData = {};
+let currentIndex = 0;
 
 export function initStats(keys, res, colors, aspects) {
   aspectKeys = keys;
   responses = res;
   statsColors = colors;
   aspectsData = aspects;
+  currentIndex = 0;
   buildStats();
 }
 
 function buildStats() {
   const container = document.getElementById('stats-content');
   container.innerHTML = '';
-  aspectKeys.forEach(k => {
-    const item = document.createElement('div');
-    item.className = 'stats-item';
 
-    const img = document.createElement('img');
-    img.src = aspectsData[k].image;
-    img.alt = k;
-    item.appendChild(img);
+  const display = document.createElement('div');
+  display.className = 'stats-display';
+  container.appendChild(display);
 
-    const name = document.createElement('span');
-    name.className = 'stats-name';
-    name.textContent = k;
-    item.appendChild(name);
+  const img = document.createElement('img');
+  img.className = 'stats-aspect-image';
+  display.appendChild(img);
 
-    container.appendChild(item);
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.classList.add('stats-circle');
+  svg.setAttribute('width', '250');
+  svg.setAttribute('height', '250');
+  svg.setAttribute('viewBox', '0 0 250 250');
+  const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+  const radius = 115;
+  const circumference = 2 * Math.PI * radius;
+  circle.setAttribute('cx', '125');
+  circle.setAttribute('cy', '125');
+  circle.setAttribute('r', String(radius));
+  circle.setAttribute('stroke-width', '20');
+  circle.setAttribute('fill', 'none');
+  circle.setAttribute('stroke-dasharray', String(circumference));
+  svg.appendChild(circle);
+  display.appendChild(svg);
+
+  const name = document.createElement('div');
+  name.className = 'stats-name';
+  container.appendChild(name);
+
+  function render() {
+    const key = aspectKeys[currentIndex];
+    const level = responses[key]?.level || 0;
+    const color = statsColors[key]?.[1] || '#fff';
+    img.src = aspectsData[key].image;
+    img.alt = key;
+    name.textContent = `${key}: ${level}%`;
+    circle.setAttribute('stroke', color);
+    circle.style.filter = `drop-shadow(0 0 6px ${color}) drop-shadow(0 0 12px ${color})`;
+    circle.setAttribute('stroke-dashoffset', String(circumference * (1 - level / 100)));
+  }
+
+  render();
+
+  let startX = 0;
+  container.addEventListener('touchstart', e => {
+    startX = e.touches[0].clientX;
   });
-  applyCascade(container);
+  container.addEventListener('touchend', e => {
+    const dx = e.changedTouches[0].clientX - startX;
+    if (dx > 50) {
+      currentIndex = (currentIndex - 1 + aspectKeys.length) % aspectKeys.length;
+      render();
+    } else if (dx < -50) {
+      currentIndex = (currentIndex + 1) % aspectKeys.length;
+      render();
+    }
+  });
 }
 
 export function checkStatsPrompt() {}
-

--- a/styles.css
+++ b/styles.css
@@ -473,36 +473,42 @@ li:hover { transform: scale(1.02); }
 }
 
 #stats-content {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 20px;
-  justify-items: center;
-  padding: 20px 0;
-  margin: -60px auto 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - 100px);
+  touch-action: pan-y;
 }
 
-.stats-item img {
-  width: 75px;
-  height: 75px;
+.stats-display {
+  position: relative;
+  width: 250px;
+  height: 250px;
+}
+
+.stats-aspect-image {
+  width: 250px;
+  height: 250px;
+  display: block;
+}
+
+.stats-circle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 250px;
+  height: 250px;
+  pointer-events: none;
+  transform: rotate(-90deg);
 }
 
 .stats-name {
-  display: block;
-  margin-top: 8px;
+  margin-top: 20px;
   color: #ccc;
   text-align: center;
   font-family: 'Open Sans', sans-serif;
   font-weight: 700;
-}
-
-@media (min-width: 601px) {
-  .boxtime {
-    max-width: 624px;
-  }
-  .stats-item img {
-    width: 131px;
-    height: 131px;
-  }
 }
 
 #task-modal {


### PR DESCRIPTION
## Summary
- Show stats as a user-controlled carousel with centered aspect icons and neon progress rings
- Ask the "Nível atual" questionnaire only once and reuse saved levels
- Style stats screen for 250x250 icons with swipe navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acd94ea5048325a6f44665f7ebe97a